### PR TITLE
Enable licensed for license checking

### DIFF
--- a/.licensed.yaml
+++ b/.licensed.yaml
@@ -1,4 +1,4 @@
-ources:
+sources:
   go: true
 
 ignored:

--- a/.licensed.yaml
+++ b/.licensed.yaml
@@ -1,0 +1,30 @@
+ources:
+  go: true
+
+ignored:
+  go:
+
+allowed:
+  - mit
+  - apache-2.0
+  - bsd-2-clause
+  - bsd-3-clause
+  - isc
+  - unlicense
+  - wtfpl
+  - 0bsd
+  - zlib
+  - bsl-1.0
+  - mpl-2.0
+  - epl-2.0
+  - cddl-1.0
+  - gpl-1.0-only
+  - gpl-1.0-or-later
+  - gpl-2.0-only
+  - gpl-2.0-or-later
+  - gpl-3.0-only
+  - gpl-3.0-or-later
+  - lgpl-3.0-linking-exception
+
+apps:
+  - source_path: ./

--- a/.licenses/iot-client-go/go/golang.org/x/oauth2.dep.yml
+++ b/.licenses/iot-client-go/go/golang.org/x/oauth2.dep.yml
@@ -1,0 +1,39 @@
+---
+name: golang.org/x/oauth2
+version: v0.21.0
+type: go
+summary: Package oauth2 provides support for making OAuth2 authorized and authenticated
+  HTTP requests, as specified in RFC 6749.
+homepage: https://pkg.go.dev/golang.org/x/oauth2
+license: bsd-3-clause
+licenses:
+- sources: LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices: []

--- a/.licenses/iot-client-go/go/golang.org/x/oauth2/internal.dep.yml
+++ b/.licenses/iot-client-go/go/golang.org/x/oauth2/internal.dep.yml
@@ -1,0 +1,38 @@
+---
+name: golang.org/x/oauth2/internal
+version: v0.21.0
+type: go
+summary: Package internal contains support packages for oauth2 package.
+homepage: https://pkg.go.dev/golang.org/x/oauth2/internal
+license: bsd-3-clause
+licenses:
+- sources: oauth2@v0.21.0/LICENSE
+  text: |
+    Copyright (c) 2009 The Go Authors. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+       * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+       * Redistributions in binary form must reproduce the above
+    copyright notice, this list of conditions and the following disclaimer
+    in the documentation and/or other materials provided with the
+    distribution.
+       * Neither the name of Google Inc. nor the names of its
+    contributors may be used to endorse or promote products derived from
+    this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+notices: []

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,7 +3,7 @@ version: "3"
 tasks:
 
   license:
-    desc: Update license
+    desc: Update license files for dependencies
     cmds:
       - licensed cache
       - task: license:resolve

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,7 +11,7 @@ tasks:
 
   license:resolve:
     internal: true
-    desc: Resolve "other" licenses by fetching the homepage and looking for the license description in the HTML content.
+    desc: Resolve "other" licenses by fetching the homepage and looking for the license description in the HTML content. Note that manual review is still needed as some of the resolved dependencies will display multiple licenses but only one will apply.
     cmds:
       - |
           mapfile -t files < <(find .licenses -type f -name '*.yml' -exec sh -c 'yq -e ".license == \"other\"" "$1" > /dev/null 2>&1 && echo "$1"' _ {} \;)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -1,0 +1,36 @@
+version: "3"
+
+tasks:
+
+  license:
+    desc: Check dependency licenses
+    cmds:
+      - licensed cache
+      - task: license:fix
+      - licensed status
+
+  license:fix:
+    desc: Fix "other" licenses by fetching the homepage and extracting the license info from the HTML content.
+    cmds:
+      - |
+          mapfile -t files < <(find .licenses -type f -name '*.yml' -exec sh -c 'yq -e ".license == \"other\"" "$1" > /dev/null 2>&1 && echo "$1"' _ {} \;)
+          total=${#files[@]}
+          if (( total == 0 )); then
+            echo "No files to process."
+            exit 0
+          fi
+          count=0
+          for file in "${files[@]}"; do
+            count=$((count + 1))
+            echo "Processing $file ($count/$total), remaining: $((total - count))"
+            homepage=$(yq -r '.homepage' "$file")
+            got=$(curl --max-time 10 -s "$homepage" | \
+            grep 'aria-describedby="license-description"' | \
+            sed -n 's/.*aria-describedby="license-description"[^>]*>\([^<]*\)<.*/\1/p')
+            if [ -n "$got" ]; then
+              # Write license in lowercase and remove ", + 1 more" suffix if present
+              yq -i ".license = \"$(echo "$got" | sed 's/, + 1 more//' | tr '[:upper:]' '[:lower:]')\"" "$file"
+            else
+              echo "Could not fetch license info for $file from $homepage"
+            fi
+          done

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -3,14 +3,15 @@ version: "3"
 tasks:
 
   license:
-    desc: Check dependency licenses
+    desc: Update license
     cmds:
       - licensed cache
-      - task: license:fix
+      - task: license:resolve
       - licensed status
 
-  license:fix:
-    desc: Fix "other" licenses by fetching the homepage and extracting the license info from the HTML content.
+  license:resolve:
+    internal: true
+    desc: Resolve "other" licenses by fetching the homepage and looking for the license description in the HTML content.
     cmds:
       - |
           mapfile -t files < <(find .licenses -type f -name '*.yml' -exec sh -c 'yq -e ".license == \"other\"" "$1" > /dev/null 2>&1 && echo "$1"' _ {} \;)


### PR DESCRIPTION
We need to introduce the licensed tool to guarantee no incompatible licenses are introduced in the codebase.